### PR TITLE
native query with result class doesn't register entity with entity ma…

### DIFF
--- a/src/main/java/mydomain/model/Person.java
+++ b/src/main/java/mydomain/model/Person.java
@@ -2,27 +2,31 @@ package mydomain.model;
 
 import javax.persistence.*;
 
-@Entity
-public class Person
-{
+@Entity(name = "person")
+@SqlResultSetMappings({
+        @SqlResultSetMapping(name = "RSM_TEST",
+                entities = {@EntityResult(entityClass = Person.class)})
+})
+public class Person {
     @Id
     Long id;
 
     String name;
 
-    public Person(long id, String name)
-    {
+    public Person(long id, String name) {
         this.id = id;
         this.name = name;
     }
 
-    public Long getId()
-    {
+    public Long getId() {
         return id;
     }
 
-    public String getName()
-    {
+    public String getName() {
         return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 }

--- a/src/test/java/org/datanucleus/test/SimpleTest.java
+++ b/src/test/java/org/datanucleus/test/SimpleTest.java
@@ -1,45 +1,94 @@
 package org.datanucleus.test;
 
-import java.util.*;
-import org.junit.*;
-import javax.persistence.*;
-
-import static org.junit.Assert.*;
-import mydomain.model.*;
 import org.datanucleus.util.NucleusLogger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.function.Consumer;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+
+import mydomain.model.Person;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class SimpleTest
 {
-    @Test
-    public void testSimple()
-    {
-        NucleusLogger.GENERAL.info(">> test START");
-        EntityManagerFactory emf = Persistence.createEntityManagerFactory("MyTest");
+    private EntityManagerFactory emf;
 
+    @Before
+    public void setUp() {
+        emf = Persistence.createEntityManagerFactory("MyTest");
+        // create a single entity in a transaction
+        withTx(emf, em -> {
+            Person person = new Person(1, "name");
+            em.persist(person);
+        });
+    }
+
+    @After
+    public void tearDown() {
+        emf.close();
+    }
+
+    @Test
+    public void testNativeReadAndUpdateRSM()
+    {
+        // read the entity in using a native query and Result Set Mapping, modify its name, commit
+        withTx(emf, em -> {
+            Query q = em.createNativeQuery("select * from Person where id = 1", "RSM_TEST");
+            Person p = (Person) q.getSingleResult();
+            p.setName("RSM name");
+        });
+
+        // read the entity in again, confirm the new name
+        withTx(emf, em -> {
+            Query q = em.createNativeQuery("select * from Person where id = 1", Person.class);
+            Person p = (Person) q.getSingleResult();
+            assertThat(p.getName(), is("RSM name"));
+        });
+    }
+
+    @Test
+    public void testNativeReadAndUpdateResultClass()
+    {
+        // read the entity in using a native query and result class, modify, commit
+        withTx(emf, em -> {
+            Query q = em.createNativeQuery("select * from Person where id = 1", Person.class);
+            Person p = (Person) q.getSingleResult();
+            p.setName("result class name");
+        });
+
+        // read the entity in again, confirm the new name
+        withTx(emf, em -> {
+            Query q = em.createNativeQuery("select * from Person where id = 1", Person.class);
+            Person p = (Person) q.getSingleResult();
+            assertThat(p.getName(), is("result class name"));
+        });
+    }
+
+    private static void withTx(EntityManagerFactory emf, Consumer<EntityManager> c) {
         EntityManager em = emf.createEntityManager();
         EntityTransaction tx = em.getTransaction();
-        try
-        {
+        try {
             tx.begin();
-
-            // [INSERT code here to persist object required for testing]
+            c.accept(em);
             tx.commit();
-        }
-        catch (Throwable thr)
-        {
+        } catch (Throwable thr) {
             NucleusLogger.GENERAL.error(">> Exception in test", thr);
             fail("Failed test : " + thr.getMessage());
-        }
-        finally 
-        {
-            if (tx.isActive())
-            {
+        } finally {
+            if (tx.isActive()) {
                 tx.rollback();
             }
             em.close();
         }
-
-        emf.close();
-        NucleusLogger.GENERAL.info(">> test END");
     }
 }


### PR DESCRIPTION
…nager.

@andyjefferson I'm not a JPA expert, but this behaviour seems inconsistent:

1. entity returned from native query with result set mapping *is* known to the entity manager, and so can be updated/persisted.

2. entity returned from native query with result class *is not* known to the entity manager, and so updates fail (are ignored). 